### PR TITLE
Support tasks which do not return any value

### DIFF
--- a/django_ztaskq/models.py
+++ b/django_ztaskq/models.py
@@ -32,7 +32,7 @@ class Task(Model):
     function_name = CharField(max_length=255)
     args = PickledObjectField()
     kwargs = PickledObjectField()
-    return_value = PickledObjectField()
+    return_value = PickledObjectField(null=True)
     
     error = TextField(blank=True, null=True)
     


### PR DESCRIPTION
In databases like sqlite, an error was being thrown when the task did not return any thing. This is a fix for this issue.
