### PR TITLE
Removed picklefield import from __init__.py because it's not needed and

### DIFF
--- a/django_ztaskq/__init__.py
+++ b/django_ztaskq/__init__.py
@@ -9,7 +9,3 @@ __contact__ = "drew.h.bryant@gmail.com"
 __homepage__ = "https://github.com/awesomo/django-ztaskq"
 __docformat__ = "markdown"
 __license__ = "BSD (3 clause)"
-
-# try to import dependencies
-# repo: https://github.com/awesomo/django-picklefield
-import picklefield

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     name='django-ztaskq',
     packages=['django_ztaskq'],
     install_requires=[
+        'django-picklefield',
         'pyzmq',
     ]
 )


### PR DESCRIPTION
it causes errors when running, say, `python setup.py develop` or `python
setup.py test`. Added [django-picklefield](http://pypi.python.org/pypi/django-picklefield/) dependency to setup.py so that it gets installed automatically.
