### PR TITLE
Added delayed task support

### DIFF
--- a/django_ztaskq/__init__.py
+++ b/django_ztaskq/__init__.py
@@ -1,6 +1,6 @@
 """Django ZTaskQ based on a fork of Django ZTask."""
 
-VERSION = (0, 2, 0)
+VERSION = (0, 3, 0)
 
 __version__ = ".".join([ str(c) for c in VERSION[0:3] ]) + "".join(VERSION[3:])
 __author__ = "Drew Bryant, Jason Allum and Dave Martorana"

--- a/django_ztaskq/__init__.py
+++ b/django_ztaskq/__init__.py
@@ -1,9 +1,8 @@
 """Django ZTaskQ based on a fork of Django ZTask."""
-import os
 
 VERSION = (0, 2, 0)
 
-__version__ = ".".join(map(str, VERSION[0:3])) + "".join(VERSION[3:])
+__version__ = ".".join([ str(c) for c in VERSION[0:3] ]) + "".join(VERSION[3:])
 __author__ = "Drew Bryant, Jason Allum and Dave Martorana"
 __contact__ = "drew.h.bryant@gmail.com"
 __homepage__ = "https://github.com/awesomo/django-ztaskq"

--- a/django_ztaskq/conf/__init__.py
+++ b/django_ztaskq/conf/__init__.py
@@ -1,8 +1,10 @@
-from .settings import ZTASKD_LOG_LEVEL, ZTASKD_LOG_PATH
+from .settings import (ZTASKD_LOG_LEVEL, ZTASKD_LOG_PATH, ZTASKD_LOG_MAXBYTES,
+                       ZTASKD_LOG_BACKUP)
 import logging
+from logging.handlers import RotatingFileHandler
 
 
-def _get_logger(logfile=ZTASKD_LOG_PATH, loglevel=ZTASKD_LOG_LEVEL):
+def get_logger(name, logfile=ZTASKD_LOG_PATH, loglevel=ZTASKD_LOG_LEVEL):
     LEVELS = {
         'debug': logging.DEBUG,
         'info': logging.INFO,
@@ -11,10 +13,17 @@ def _get_logger(logfile=ZTASKD_LOG_PATH, loglevel=ZTASKD_LOG_LEVEL):
         'critical': logging.CRITICAL
     }
 
-    logger_ = logging.getLogger('ztaskd')
+    logger_ = logging.getLogger("ztaskq.%s" % name)
+    logger_.propagate = False
     logger_.setLevel(LEVELS[loglevel.lower()])
     if logfile:
-        handler = logging.FileHandler(logfile)
+        if '%(name)s' in logfile:
+            filename = logfile % { 'name': name }
+        else:
+            filename = logfile
+        handler = RotatingFileHandler(filename=filename,
+                                      maxBytes=ZTASKD_LOG_MAXBYTES,
+                                      backupCount=ZTASKD_LOG_BACKUP)
     else:
         handler = logging.StreamHandler()
 
@@ -25,6 +34,3 @@ def _get_logger(logfile=ZTASKD_LOG_PATH, loglevel=ZTASKD_LOG_LEVEL):
     logger_.addHandler(handler)
 
     return logger_
-
-
-logger = _get_logger()

--- a/django_ztaskq/conf/__init__.py
+++ b/django_ztaskq/conf/__init__.py
@@ -1,6 +1,7 @@
 from .settings import ZTASKD_LOG_LEVEL, ZTASKD_LOG_PATH
 import logging
 
+
 def _get_logger(logfile=ZTASKD_LOG_PATH, loglevel=ZTASKD_LOG_LEVEL):
     LEVELS = {
         'debug': logging.DEBUG,
@@ -9,18 +10,21 @@ def _get_logger(logfile=ZTASKD_LOG_PATH, loglevel=ZTASKD_LOG_LEVEL):
         'error': logging.ERROR,
         'critical': logging.CRITICAL
     }
-    
-    logger = logging.getLogger('ztaskd')
-    logger.setLevel(LEVELS[loglevel.lower()])
+
+    logger_ = logging.getLogger('ztaskd')
+    logger_.setLevel(LEVELS[loglevel.lower()])
     if logfile:
         handler = logging.FileHandler(logfile)
     else:
         handler = logging.StreamHandler()
-    
-    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+    formatter = logging.Formatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    )
     handler.setFormatter(formatter)
-    logger.addHandler(handler)
-    
-    return logger
+    logger_.addHandler(handler)
+
+    return logger_
+
 
 logger = _get_logger()

--- a/django_ztaskq/conf/settings.py
+++ b/django_ztaskq/conf/settings.py
@@ -7,3 +7,5 @@ ZTASK_INTERNAL_QUEUE_URL = getattr(settings, 'ZTASK_INTERNAL_QUEUE_URL',
 ZTASKD_ON_LOAD = getattr(settings, 'ZTASKD_ON_LOAD', ())
 ZTASKD_LOG_LEVEL = getattr(settings, 'ZTASKD_LOG_LEVEL', 'info')
 ZTASKD_LOG_PATH = getattr(settings, 'ZTASKD_LOG_PATH', None)
+ZTASKD_LOG_MAXBYTES = getattr(settings, 'ZTASKD_LOG_MAXBYTES', 36864)
+ZTASKD_LOG_BACKUP = getattr(settings, 'ZTASKD_LOG_BACKUP', 4)

--- a/django_ztaskq/conf/settings.py
+++ b/django_ztaskq/conf/settings.py
@@ -2,8 +2,8 @@ from django.conf import settings
 
 ZTASKD_URL = getattr(settings, 'ZTASKD_URL', 'tcp://127.0.0.1:5555')
 ZTASK_WORKER_URL = getattr(settings, 'ZTASK_WORKER_URL', 'tcp://127.0.0.1:5556')
-ZTASK_INTERNAL_QUEUE_URL = getattr(settings, 'ZTASK_INTERNAL_QUEUE_URL', 'ipc:///tmp/django_ztask_internal_queue')
-
+ZTASK_INTERNAL_QUEUE_URL = getattr(settings, 'ZTASK_INTERNAL_QUEUE_URL',
+                                   'inproc://django_ztask_internal_queue')
 ZTASKD_ON_LOAD = getattr(settings, 'ZTASKD_ON_LOAD', ())
 ZTASKD_LOG_LEVEL = getattr(settings, 'ZTASKD_LOG_LEVEL', 'info')
 ZTASKD_LOG_PATH = getattr(settings, 'ZTASKD_LOG_PATH', None)

--- a/django_ztaskq/context.py
+++ b/django_ztaskq/context.py
@@ -1,3 +1,4 @@
 import zmq
 
+
 shared_context = zmq.Context()

--- a/django_ztaskq/decorators.py
+++ b/django_ztaskq/decorators.py
@@ -1,50 +1,52 @@
 import uuid
 import logging
-import types
 from functools import wraps
+
 
 def ztask(memoize=False):
     """Decorator to augment function (task) with async computation ability.
-    
+
     :param memoize: should function calls with the same args be memoized?
     :type memoize: bool
-    
-    The memoize flag allows functions to be marked 
-    
+
+    The memoize flag allows functions to be marked
+
     """
     from .conf import settings
     try:
         from zmq import PUSH
-    except:
+    except ImportError:
         from zmq import DOWNSTREAM as PUSH
-    
+
     def wrapper(func):
         function_name = '%s.%s' % (func.__module__, func.__name__)
-        
+
         logger = logging.getLogger('ztaskd')
         logger.info('Registered task: %s' % function_name)
-        
+
         from .context import shared_context as context
         socket = context.socket(PUSH)
         socket.connect(settings.ZTASKD_URL)
-        
+
         @wraps(func)
         def _async(*args, **kwargs):
-            """Call the function asynchronously by placing it in a task queue."""
+            """Call the function asynchronously by placing it in a task queue.
+            """
             if memoize: # same func and args will have same taskid
-                taskid = str(uuid.uuid5(uuid.NAMESPACE_URL, 
+                taskid = str(uuid.uuid5(uuid.NAMESPACE_URL,
                     '%r-%r-%r' % (function_name, args, kwargs)))
-            else: # give a random unique id regardless of input (almost certainly unique)
+            else:
+                # give a random unique id regardless of input
+                # (almost certainly unique)
                 taskid = str(uuid.uuid4())
-            
             try:
                 socket.send_pyobj((taskid, function_name, args, kwargs))
-            except Exception, e:
+            except Exception: # pylint: disable=W0703
                 logger.error('Failed to submit task to ztaskd: '
                     '%s(args=%r, kwargs=%r)' % (function_name, args, kwargs))
             return taskid
-        
+
         setattr(func, 'async', _async)
         return func
-    
+
     return wrapper

--- a/django_ztaskq/decorators.py
+++ b/django_ztaskq/decorators.py
@@ -32,6 +32,7 @@ def ztask(memoize=False):
         def _async(*args, **kwargs):
             """Call the function asynchronously by placing it in a task queue.
             """
+            ztaskq_delay = kwargs.pop('ztaskq_delay', 0)
             if memoize: # same func and args will have same taskid
                 taskid = str(uuid.uuid5(uuid.NAMESPACE_URL,
                     '%r-%r-%r' % (function_name, args, kwargs)))
@@ -40,7 +41,9 @@ def ztask(memoize=False):
                 # (almost certainly unique)
                 taskid = str(uuid.uuid4())
             try:
-                socket.send_pyobj((taskid, function_name, args, kwargs))
+                socket.send_pyobj(
+                    (taskid, function_name, args, kwargs, ztaskq_delay)
+                )
             except Exception: # pylint: disable=W0703
                 logger.error('Failed to submit task to ztaskd: '
                     '%s(args=%r, kwargs=%r)' % (function_name, args, kwargs))

--- a/django_ztaskq/management/commands/workerd.py
+++ b/django_ztaskq/management/commands/workerd.py
@@ -1,28 +1,46 @@
+import sys
 import atexit
 from zmq import PULL
 from django.core.management.base import BaseCommand
 from ...models import Task
-from ...conf import settings, logger
+from ...conf import settings, get_logger
 from ...context import shared_context as context
 
 
 class Command(BaseCommand):
 
-    args = ''
-    help = 'Start a worker instance.'
+    args = 'NAME'
+    help = (
+        'Start a worker instance.\n\n'
+        'NAME is the name of the worker, which is necessary to differentiate \n'
+        'correctly between them.\n\n'
+        'Example: manage.py workerd worker1'
+    )
 
     def handle(self, *args, **options): # pylint: disable=W0613
-        logger.info(
-            "Worker listening on %s." % (settings.ZTASK_WORKER_URL,))
-        socket = context.socket(PULL)
-        def _shutdown():
-            logger.debug('Shutting down nicely')
-            socket.close()
-        atexit.register(_shutdown)
-        socket.connect(settings.ZTASK_WORKER_URL)
-        while True:
-            task_id, = socket.recv_pyobj()
-            logger.info('Worker received task (%s)' % (str(task_id),))
-            task = Task.objects.get(pk=task_id)
-            task.run()
-
+        if len(args) < 1:
+            sys.stderr.write(
+                "You must specify a name for this worker! See '%s -h'\n" % (
+                    " ".join(sys.argv[:2]),
+                )
+            )
+            sys.stderr.flush()
+            sys.exit(-1)
+        try:
+            name = args[0]
+            logger = get_logger(name)
+            logger.info(
+                "Worker listening on %s." % (settings.ZTASK_WORKER_URL,))
+            socket = context.socket(PULL)
+            def _shutdown():
+                logger.debug('Shutting down nicely')
+                socket.close()
+            atexit.register(_shutdown)
+            socket.connect(settings.ZTASK_WORKER_URL)
+            while True:
+                task_id, = socket.recv_pyobj()
+                logger.info('Worker received task (%s)' % (str(task_id),))
+                task = Task.objects.get(pk=task_id)
+                task.run(logger)
+        except KeyboardInterrupt:
+            raise sys.exit(0)

--- a/django_ztaskq/management/commands/workerd.py
+++ b/django_ztaskq/management/commands/workerd.py
@@ -1,40 +1,28 @@
-from optparse import make_option
-try:
-    from zmq import PULL
-except ImportError:
-    from zmq import UPSTREAM as PULL
+import atexit
+from zmq import PULL
 from django.core.management.base import BaseCommand
-from django.utils import autoreload
 from ...models import Task
 from ...conf import settings, logger
 from ...context import shared_context as context
 
 
 class Command(BaseCommand):
-    option_list = BaseCommand.option_list + (
-        make_option('--noreload',
-            action='store_false', dest='use_reloader', default=True,
-            help='Tells Django to NOT use the auto-reloader.'),
-    )
+
     args = ''
     help = 'Start a worker instance.'
 
     def handle(self, *args, **options): # pylint: disable=W0613
-        use_reloader = options.get('use_reloader', True)
-
-        if use_reloader:
-            autoreload.main(self._handle)
-        else:
-            self._handle()
-
-    def _handle(self):
-        logger.info("Worker listening on %s." % (settings.ZTASK_WORKER_URL,))
-
+        logger.info(
+            "Worker listening on %s." % (settings.ZTASK_WORKER_URL,))
         socket = context.socket(PULL)
+        def _shutdown():
+            logger.debug('Shutting down nicely')
+            socket.close()
+        atexit.register(_shutdown)
         socket.connect(settings.ZTASK_WORKER_URL)
-
         while True:
             task_id, = socket.recv_pyobj()
             logger.info('Worker received task (%s)' % (str(task_id),))
             task = Task.objects.get(pk=task_id)
             task.run()
+

--- a/django_ztaskq/management/commands/workerd.py
+++ b/django_ztaskq/management/commands/workerd.py
@@ -1,51 +1,40 @@
-from django.core.management.base import BaseCommand
-from django.utils import autoreload
-#
-from ...models import Task
-#
-from ...conf import settings, logger
-from ...context import shared_context as context
-#
-import zmq
+from optparse import make_option
 try:
     from zmq import PULL
-except:
+except ImportError:
     from zmq import UPSTREAM as PULL
-#
-from optparse import make_option
-import sys
-import traceback
+from django.core.management.base import BaseCommand
+from django.utils import autoreload
+from ...models import Task
+from ...conf import settings, logger
+from ...context import shared_context as context
 
-import pickle
-import datetime, time
 
 class Command(BaseCommand):
     option_list = BaseCommand.option_list + (
-        make_option('--noreload', 
-            action='store_false', dest='use_reloader', default=True, 
+        make_option('--noreload',
+            action='store_false', dest='use_reloader', default=True,
             help='Tells Django to NOT use the auto-reloader.'),
     )
     args = ''
     help = 'Start a worker instance.'
-    
-    def handle(self, *args, **options):
+
+    def handle(self, *args, **options): # pylint: disable=W0613
         use_reloader = options.get('use_reloader', True)
-        
+
         if use_reloader:
-            autoreload.main(lambda: self._handle())
+            autoreload.main(self._handle)
         else:
             self._handle()
-    
+
     def _handle(self):
         logger.info("Worker listening on %s." % (settings.ZTASK_WORKER_URL,))
-        
+
         socket = context.socket(PULL)
         socket.connect(settings.ZTASK_WORKER_URL)
-        
+
         while True:
             task_id, = socket.recv_pyobj()
             logger.info('Worker received task (%s)' % (str(task_id),))
             task = Task.objects.get(pk=task_id)
             task.run()
-        
-    

--- a/django_ztaskq/management/commands/ztaskd.py
+++ b/django_ztaskq/management/commands/ztaskd.py
@@ -1,127 +1,144 @@
 import sys
 import traceback
-import pickle
-import datetime, time
 from threading import Thread
 from optparse import make_option
-
-import zmq
 from zmq.core.device import device
 try:
     from zmq import PUSH
-except:
+except ImportError:
     from zmq import DOWNSTREAM as PUSH
 try:
     from zmq import PULL
-except:
+except ImportError:
     from zmq import UPSTREAM as PULL
-
 from django.core.management.base import BaseCommand
 from django.utils import autoreload
-
 from ...models import Task
 from ...conf import settings, logger
 from ...context import shared_context as context
 
+
 class DeviceType(object):
     QUEUE, FORWARDER, STREAMER = range(3)
 
-def _async_queue():
-    """Handles the blocking messaging for the worker queue."""
-    logger.info('Async queue thread is running.')
-    queue_socket = context.socket(PULL)
-    queue_socket.connect(settings.ZTASK_INTERNAL_QUEUE_URL)
-    
-    worker_socket = context.socket(PUSH)
-    worker_socket.bind(settings.ZTASK_WORKER_URL)
-    
-    d = device(DeviceType.STREAMER, 
-        queue_socket, worker_socket)
 
-def _serve():
-    """Handles immediate logging of tasks in the Django model."""
-    logger.info('Server thread is running.')
-    
-    server_socket = context.socket(PULL)
-    server_socket.bind(settings.ZTASKD_URL)
-    
-    queue_socket = context.socket(PUSH)
-    queue_socket.bind(settings.ZTASK_INTERNAL_QUEUE_URL)
-    
-    while True:
-        _recv_and_enqueue(server_socket, queue_socket)
+class QueuingThread(Thread):
+    """Handles passing the tasks to the worker process.
+    """
+
+    def __init__(self, group=None, name=None):
+        super(QueuingThread, self).__init__(group=group, name=name)
+        self.zmq_device = None
+        self.queue_socket = context.socket(PULL)
+        self.worker_socket = context.socket(PUSH)
+
+    def bind_sockets(self):
+        self.queue_socket.connect(settings.ZTASK_INTERNAL_QUEUE_URL)
+        self.worker_socket.bind(settings.ZTASK_WORKER_URL)
+
+    def run(self):
+        logger.info('Queue thread is running.')
+        self.bind_sockets()
+        self.zmq_device = device(
+            DeviceType.STREAMER,
+            self.queue_socket,
+            self.worker_socket
+        )
+
+
+class ServerThread(Thread):
+    """Handles logging of tasks in the Django model.
+
+    It also passes the task to the queueing component"""
+
+    def __init__(self, group=None, name=None):
+        super(ServerThread, self).__init__(group=group, name=name)
+        self.server_socket = context.socket(PULL)
+        self.queue_socket = context.socket(PUSH)
+
+    def bind_sockets(self):
+        self.server_socket.bind(settings.ZTASKD_URL)
+        self.queue_socket.bind(settings.ZTASK_INTERNAL_QUEUE_URL)
+
+    def recv_and_enqueue(self):
+        try:
+            id, function, args, kwargs = self.server_socket.recv_pyobj()
+            task, was_created = Task.objects.get_or_create(
+                taskid=id,
+                function_name=function,
+                args=args,
+                kwargs=kwargs,
+            )
+            logger.info('Listed task in django database (%r)' % task.pk)
+            if was_created:
+                self.queue_socket.send_pyobj((task.pk,))
+                logger.info('Passed task to worker queue (%r)' % task.pk)
+            else:
+                logger.info(
+                    'Ignoring task (%r) because it is already computed.' % (
+                        task.pk,
+                    )
+                )
+        except Exception, e: # pylint: disable=W0703
+            logger.error('Error setting up function. Details:\n%s' % e)
+            traceback.print_exc(e)
+
+    def run(self):
+        logger.info('Server thread is running.')
+        self.bind_sockets()
+        while True:
+            self.recv_and_enqueue()
 
 
 class Command(BaseCommand):
     option_list = BaseCommand.option_list + (
-        make_option('--noreload', 
-            action='store_false', dest='use_reloader', default=True, 
+        make_option('--noreload',
+            action='store_false', dest='use_reloader', default=True,
             help='Tells Django to NOT use the auto-reloader.'),
-        make_option('--replayfailed', 
-            action='store_true', dest='replay_failed', default=False, 
+        make_option('--replayfailed',
+            action='store_true', dest='replay_failed', default=False,
             help='Replays all failed calls in the db'),
     )
     args = ''
     help = 'Start the ztaskd server'
-    
-    def handle(self, *args, **options):
+
+    def handle(self, *args, **options): # pylint: disable=W0613
         use_reloader = options.get('use_reloader', True)
-        
+
         if use_reloader:
             autoreload.main(lambda: self._handle(use_reloader))
         else:
             self._handle(use_reloader)
-    
+
+    def _on_load(self):
+        """Execute any startup function callbacks associated with ztaskd.
+        """
+
+        for callable_name in settings.ZTASKD_ON_LOAD:
+            logger.info("ON_LOAD calling %s" % callable_name)
+
+            parts = callable_name.split('.')
+            module_name = '.'.join(parts[:-1])
+            member_name = parts[-1]
+
+            if not module_name in sys.modules:
+                __import__(module_name)
+
+            callable_fn = getattr(sys.modules[module_name], member_name)
+            callable_fn()
+
     def _handle(self, use_reloader):
-        logger.info("%sServer starting on %s." % ('Development ' if use_reloader else '', settings.ZTASKD_URL))
-        _on_load()
-        
-        # TODO: how should these threads be killed when reloaded
-        queue_thread = Thread(target=_async_queue)
-        queue_thread.start()
-        
-        serve_thread = Thread(target=_serve)
-        serve_thread.start()
-    
-
-def _recv_and_enqueue(server_socket, worker_socket):
-    try:
-        
-        taskid, function_name, args, kwargs = server_socket.recv_pyobj()
-        
-        task, was_created = Task.objects.get_or_create(
-            taskid=taskid,
-            function_name=function_name, 
-            args=args,
-            kwargs=kwargs,
-        )
-        logger.info('Listed task in django database (%r)' % task.pk)
-        
-        if was_created:
-            worker_socket.send_pyobj((str(task.pk),))
-            logger.info('Passed task to worker queue (%r)' % task.pk)
+        if use_reloader:
+            logger.info(
+                'Development server starting on %s.' % settings.ZTASKD_URL
+            )
         else:
-            logger.info('Ignoring task (%r) because it is already computed.' % task.pk)
-        
-        
-    except Exception, e:
-        logger.error('Error setting up function. Details:\n%s' % e)
-        traceback.print_exc(e)
-    
-
-def _on_load():
-    """Execute any startup function callbacks associated with ztaskd."""
-    
-    for callable_name in settings.ZTASKD_ON_LOAD:
-        logger.info("ON_LOAD calling %s" % callable_name)
-        
-        parts = callable_name.split('.')
-        module_name = '.'.join(parts[:-1])
-        member_name = parts[-1]
-        
-        if not module_name in sys.modules:
-            __import__(module_name)
-        
-        callable_fn = getattr(sys.modules[module_name], member_name)
-        callable_fn()
-
+            logger.info(
+                'Production server starting on %s.' % settings.ZTASKD_URL
+            )
+        self._on_load()
+        # TODO: how should these threads be killed when reloaded
+        queue_thread = QueuingThread()
+        queue_thread.start()
+        serve_thread = ServerThread()
+        serve_thread.start()

--- a/django_ztaskq/management/commands/ztaskd.py
+++ b/django_ztaskq/management/commands/ztaskd.py
@@ -1,81 +1,145 @@
 import sys
 import traceback
-from threading import Thread
-from optparse import make_option
+import atexit
+from datetime import datetime, timedelta
+from threading import Thread, Lock, Timer
+from pytz import utc
+from zmq import STREAMER, PUSH, PULL
 from zmq.core.device import device
-try:
-    from zmq import PUSH
-except ImportError:
-    from zmq import DOWNSTREAM as PUSH
-try:
-    from zmq import PULL
-except ImportError:
-    from zmq import UPSTREAM as PULL
+from zmq.core.error import ZMQError
 from django.core.management.base import BaseCommand
-from django.utils import autoreload
-from ...models import Task
+from ...models import Task, Status
 from ...conf import settings, logger
 from ...context import shared_context as context
 
 
-class DeviceType(object):
-    QUEUE, FORWARDER, STREAMER = range(3)
+def queue(task_pk):
+    queue_socket = context.socket(PUSH)
+    queue_socket.connect(settings.ZTASK_INTERNAL_QUEUE_URL)
+    queue_socket.send_pyobj((str(task_pk),))
+    logger.info('Passed task to worker queue (%r)' % task_pk)
 
 
-class QueuingThread(Thread):
-    """Handles passing the tasks to the worker process.
+class ThreadPool(object):
+
+    def __init__(self):
+        self.threads = {}
+        self.lock = Lock()
+
+    def spawn(self, task_pk, delay=0):
+        with self.lock:
+            self._shutdown()
+            kwargs = {
+                'task_pk': task_pk
+            }
+            if delay > 0:
+                thread = Timer(float(delay), queue, kwargs=kwargs)
+            else:
+                thread = Thread(target=queue, kwargs=kwargs)
+            self.threads[thread.name] = thread
+            logger.debug('Added thread %s' % thread.name)
+            self.threads[thread.name].start()
+            logger.debug('Started thread %s' % thread.name)
+
+    def _shutdown(self, all=False):
+        keys = self.threads.keys()
+        logger.debug('Current active threads: %s' % ', '.join(keys))
+        for thread_name in keys:
+            if all:
+                if hasattr(self.threads[thread_name], 'cancel'):
+                    self.threads[thread_name].cancel()
+                if self.threads[thread_name].is_alive():
+                    self.threads[thread_name].join()
+            if not self.threads[thread_name].is_alive():
+                del self.threads[thread_name]
+                logger.debug('Removed spent thread %s' % thread_name)
+
+    def shutdown(self):
+        with self.lock:
+            self._shutdown(all=True)
+
+
+class BouncerThread(Thread):
+    """A simple thread that bounces data to the worker.
     """
 
     def __init__(self, group=None, name=None):
-        super(QueuingThread, self).__init__(group=group, name=name)
-        self.zmq_device = None
+        super(BouncerThread, self).__init__(group=group, name=name)
         self.queue_socket = context.socket(PULL)
         self.worker_socket = context.socket(PUSH)
-
-    def bind_sockets(self):
-        self.queue_socket.connect(settings.ZTASK_INTERNAL_QUEUE_URL)
-        self.worker_socket.bind(settings.ZTASK_WORKER_URL)
+        self.device = None
+        self.daemon = True
 
     def run(self):
-        logger.info('Queue thread is running.')
-        self.bind_sockets()
-        self.zmq_device = device(
-            DeviceType.STREAMER,
-            self.queue_socket,
-            self.worker_socket
-        )
+        self.queue_socket.bind(settings.ZTASK_INTERNAL_QUEUE_URL)
+        self.worker_socket.bind(settings.ZTASK_WORKER_URL)
+        try:
+            self.device = device(STREAMER,
+                                 self.queue_socket,
+                                 self.worker_socket)
+        except ZMQError, e:
+            if e.errno == 156384765:
+                self.queue_socket.close()
+                self.worker_socket.close()
+            else:
+                raise e
 
 
-class ServerThread(Thread):
-    """Handles logging of tasks in the Django model.
+class Command(BaseCommand):
 
-    It also passes the task to the queueing component"""
+    args = ''
+    help = 'Start the ztaskd server'
 
-    def __init__(self, group=None, name=None):
-        super(ServerThread, self).__init__(group=group, name=name)
+    def __init__(self):
+        super(Command, self).__init__()
         self.server_socket = context.socket(PULL)
-        self.queue_socket = context.socket(PUSH)
+        self.threads = ThreadPool()
+        self.bouncer_thread = BouncerThread()
+
+    def shutdown(self):
+        logger.info('Shutting down nicely')
+        logger.debug('Closing connections')
+        self.server_socket.close()
+        logger.debug('Terminating threads')
+        self.threads.shutdown()
+        context.term()
 
     def bind_sockets(self):
         self.server_socket.bind(settings.ZTASKD_URL)
-        self.queue_socket.bind(settings.ZTASK_INTERNAL_QUEUE_URL)
+
+    def enqueue_leftover(self):
+        logger.info('Enqueuing left-over tasks...')
+        queued_tasks = Task.objects.filter(status=Status.QUEUED)
+        now = utc.localize(datetime.utcnow())
+        for task in queued_tasks:
+            delta = task.queued - now
+            delay = int(delta.total_seconds())
+            if delay < 0:
+                delay = 0
+            self.enqueue_task(task, delay)
+        logger.info('Left-over tasks enqueued')
+
+    def enqueue_task(self, task, delay):
+        self.threads.spawn(task_pk=task.pk, delay=delay)
+        logger.info('Enqueued task (%r)' % task.pk)
 
     def recv_and_enqueue(self):
         try:
-            id, function, args, kwargs = self.server_socket.recv_pyobj()
+            id, function, args, kwargs, delay = self.server_socket.recv_pyobj()
+            queued = utc.localize(datetime.utcnow() + timedelta(seconds=delay))
             task, was_created = Task.objects.get_or_create(
                 taskid=id,
                 function_name=function,
                 args=args,
                 kwargs=kwargs,
+                queued=queued
             )
             logger.info('Listed task in django database (%r)' % task.pk)
             if was_created:
-                self.queue_socket.send_pyobj((task.pk,))
-                logger.info('Passed task to worker queue (%r)' % task.pk)
+                self.enqueue_task(task, delay)
             else:
-                logger.info(
-                    'Ignoring task (%r) because it is already computed.' % (
+                logger.warning(
+                    'Ignoring task (%r) because it is already present.' % (
                         task.pk,
                     )
                 )
@@ -83,37 +147,12 @@ class ServerThread(Thread):
             logger.error('Error setting up function. Details:\n%s' % e)
             traceback.print_exc(e)
 
-    def run(self):
-        logger.info('Server thread is running.')
-        self.bind_sockets()
-        while True:
-            self.recv_and_enqueue()
-
-
-class Command(BaseCommand):
-    option_list = BaseCommand.option_list + (
-        make_option('--noreload',
-            action='store_false', dest='use_reloader', default=True,
-            help='Tells Django to NOT use the auto-reloader.'),
-        make_option('--replayfailed',
-            action='store_true', dest='replay_failed', default=False,
-            help='Replays all failed calls in the db'),
-    )
-    args = ''
-    help = 'Start the ztaskd server'
-
-    def handle(self, *args, **options): # pylint: disable=W0613
-        use_reloader = options.get('use_reloader', True)
-
-        if use_reloader:
-            autoreload.main(lambda: self._handle(use_reloader))
-        else:
-            self._handle(use_reloader)
-
     def _on_load(self):
         """Execute any startup function callbacks associated with ztaskd.
         """
-
+        self.bind_sockets()
+        self.bouncer_thread.start()
+        self.enqueue_leftover()
         for callable_name in settings.ZTASKD_ON_LOAD:
             logger.info("ON_LOAD calling %s" % callable_name)
 
@@ -127,18 +166,11 @@ class Command(BaseCommand):
             callable_fn = getattr(sys.modules[module_name], member_name)
             callable_fn()
 
-    def _handle(self, use_reloader):
-        if use_reloader:
-            logger.info(
-                'Development server starting on %s.' % settings.ZTASKD_URL
-            )
-        else:
-            logger.info(
-                'Production server starting on %s.' % settings.ZTASKD_URL
-            )
+    def handle(self, *args, **options): # pylint: disable=W0613
+        logger.info(
+            'Server starting on %s.' % settings.ZTASKD_URL
+        )
+        atexit.register(self.shutdown)
         self._on_load()
-        # TODO: how should these threads be killed when reloaded
-        queue_thread = QueuingThread()
-        queue_thread.start()
-        serve_thread = ServerThread()
-        serve_thread.start()
+        while True:
+            self.recv_and_enqueue()

--- a/django_ztaskq/management/commands/ztaskd.py
+++ b/django_ztaskq/management/commands/ztaskd.py
@@ -9,8 +9,11 @@ from zmq.core.device import device
 from zmq.core.error import ZMQError
 from django.core.management.base import BaseCommand
 from ...models import Task, Status
-from ...conf import settings, logger
+from ...conf import settings, get_logger
 from ...context import shared_context as context
+
+
+logger = get_logger('ztaskd')
 
 
 def queue(task_pk):
@@ -167,10 +170,13 @@ class Command(BaseCommand):
             callable_fn()
 
     def handle(self, *args, **options): # pylint: disable=W0613
-        logger.info(
-            'Server starting on %s.' % settings.ZTASKD_URL
-        )
-        atexit.register(self.shutdown)
-        self._on_load()
-        while True:
-            self.recv_and_enqueue()
+        try:
+            logger.info(
+                'Server starting on %s.' % settings.ZTASKD_URL
+            )
+            atexit.register(self.shutdown)
+            self._on_load()
+            while True:
+                self.recv_and_enqueue()
+        except KeyboardInterrupt:
+            raise SystemExit()

--- a/django_ztaskq/models.py
+++ b/django_ztaskq/models.py
@@ -1,15 +1,11 @@
 import datetime
-import time
 import sys
-import traceback
-import pickle
-import json
 from pytz import utc
-
 from picklefield import PickledObjectField
-from django.db.models import *
+from django.core.exceptions import ObjectDoesNotExist
+from django.db.models import Model, CharField, TextField, DateTimeField
+from .conf import logger
 
-from .conf import settings, logger
 
 class Status(object):
     """Enum-style class of possible task statuses."""
@@ -17,6 +13,7 @@ class Status(object):
     RUNNING = u'R'
     COMPLETED = u'C'
     FAILED = u'F'
+
 
 # pretty forms for the admin interface
 STATUS_CHOICES = (
@@ -26,73 +23,81 @@ STATUS_CHOICES = (
     (Status.FAILED, u'Failed'),
 )
 
-_func_cache = {} # could be a classwide "static" member (may have to override __new__)
+
+_func_cache = {} # could be a classwide "static" member
+                 # (may have to override __new__)
+
+
 class Task(Model):
+    """The queued task, persisted in the database
+    (so it can be polled for status)
+    """
+
     taskid = CharField(max_length=36, primary_key=True)
-    
+
     function_name = CharField(max_length=255)
     args = PickledObjectField()
     kwargs = PickledObjectField()
     return_value = PickledObjectField(null=True)
-    
+
     error = TextField(blank=True, null=True)
-    
+
     queued = DateTimeField(blank=True, null=True)
     started = DateTimeField(blank=True, null=True)
     finished = DateTimeField(blank=True, null=True)
-    
-    status = CharField(max_length=1, choices=STATUS_CHOICES, 
+
+    status = CharField(max_length=1, choices=STATUS_CHOICES,
         default=Status.QUEUED)
-    
-    def save(self, *args, **kwargs):
-        if not self.queued:
-            self.queued = utc.localize(datetime.datetime.utcnow())
-        super(Task, self).save(*args, **kwargs)
-    
+
     class Meta:
         db_table = 'django_ztaskq_task'
-    
+
     @classmethod
     def run_task(cls, task_id):
         try:
             task = cls.objects.get(pk=task_id)
-        except Exception, e:
+        except ObjectDoesNotExist, e:
             logger.info('Could not get task with id %s:\n%s' % (task_id, e))
             return
         task.run()
-    
+
+    def save(self, *args, **kwargs):
+        if not self.queued:
+            self.queued = utc.localize(datetime.datetime.utcnow())
+        super(Task, self).save(*args, **kwargs)
+
     def mark_running(self):
         self.status = Status.RUNNING
         self.started = utc.localize(datetime.datetime.utcnow())
-        
+
         self.save()
-    
+
     def mark_complete(self, success=True, delete=False, error_msg=''):
         """Mark the task as finished (success/failure)
-        
+
         The error message is only used if success is False.
-        
+
         """
         if delete:
             self.delete()
             return
-        
+
         self.status = Status.COMPLETED if success else Status.FAILED
         if not success:
             self.error = error_msg
         self.finished = utc.localize(datetime.datetime.utcnow())
-        
+
         self.save()
-    
+
     def run(self):
-        
+
         function_name = self.function_name
         args = self.args
         kwargs = self.kwargs
-        
+
         self.mark_running()
         logger.info('Executing task function (%s)' % function_name)
-        
+
         try:
             function = _func_cache[function_name]
         except KeyError:
@@ -103,19 +108,22 @@ class Task(Model):
                 __import__(module_name)
             function = getattr(sys.modules[module_name], member_name)
             _func_cache[function_name] = function
-        
+
         try:
-            logger.info('Task.run is calling %r(%r, %r)' % (function, args, kwargs))
+            logger.info('Task.run is calling %r(%r, %r)' % (
+                    function, args, kwargs))
             return_value = function(*args, **kwargs)
             logger.info('Successfully finished the function call.')
-        except Exception, e:
-            traceback = sys.last_traceback if hasattr(sys, 'last_traceback') else 'no traceback available'
+        except Exception:
+            traceback = 'no traceback available'
+            if hasattr(sys, 'last_traceback'):
+                traceback = sys.last_traceback
             self.mark_complete(success=False, error_msg=traceback)
-            logger.error('Error calling %s. Details:\n%s' % (function_name, traceback))
+            logger.error('Error calling %s. Details:\n%s' % (
+                    function_name, traceback))
             raise
         else:
             self.return_value = return_value
             self.save()
             self.mark_complete(success=True)
             logger.info('Called %s successfully' % function_name)
-

--- a/django_ztaskq/models.py
+++ b/django_ztaskq/models.py
@@ -61,11 +61,6 @@ class Task(Model):
             return
         task.run()
 
-    def save(self, *args, **kwargs):
-        if not self.queued:
-            self.queued = utc.localize(datetime.datetime.utcnow())
-        super(Task, self).save(*args, **kwargs)
-
     def mark_running(self):
         self.status = Status.RUNNING
         self.started = utc.localize(datetime.datetime.utcnow())

--- a/django_ztaskq/models.py
+++ b/django_ztaskq/models.py
@@ -4,7 +4,6 @@ from pytz import utc
 from picklefield import PickledObjectField
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Model, CharField, TextField, DateTimeField
-from .conf import logger
 
 
 class Status(object):
@@ -53,13 +52,13 @@ class Task(Model):
         db_table = 'django_ztaskq_task'
 
     @classmethod
-    def run_task(cls, task_id):
+    def run_task(cls, task_id, logger):
         try:
             task = cls.objects.get(pk=task_id)
         except ObjectDoesNotExist, e:
             logger.info('Could not get task with id %s:\n%s' % (task_id, e))
             return
-        task.run()
+        task.run(logger)
 
     def mark_running(self):
         self.status = Status.RUNNING
@@ -84,7 +83,7 @@ class Task(Model):
 
         self.save()
 
-    def run(self):
+    def run(self, logger):
 
         function_name = self.function_name
         args = self.args

--- a/django_ztaskq/models.py
+++ b/django_ztaskq/models.py
@@ -4,6 +4,7 @@ import sys
 import traceback
 import pickle
 import json
+from pytz import utc
 
 from picklefield import PickledObjectField
 from django.db.models import *
@@ -45,7 +46,7 @@ class Task(Model):
     
     def save(self, *args, **kwargs):
         if not self.queued:
-            self.queued = datetime.datetime.utcnow()
+            self.queued = utc.localize(datetime.datetime.utcnow())
         super(Task, self).save(*args, **kwargs)
     
     class Meta:
@@ -62,7 +63,7 @@ class Task(Model):
     
     def mark_running(self):
         self.status = Status.RUNNING
-        self.started = datetime.datetime.utcnow()
+        self.started = utc.localize(datetime.datetime.utcnow())
         
         self.save()
     
@@ -79,7 +80,7 @@ class Task(Model):
         self.status = Status.COMPLETED if success else Status.FAILED
         if not success:
             self.error = error_msg
-        self.finished = datetime.datetime.utcnow()
+        self.finished = utc.localize(datetime.datetime.utcnow())
         
         self.save()
     

--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,6 @@ setup(
     install_requires=[
         'django-picklefield',
         'pyzmq',
+        'pytz'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 try:
     from setuptools import setup
-except:
+except ImportError:
     from distutils.core import setup
 import django_ztaskq as distmeta
 


### PR DESCRIPTION
Hi,

I have added delayed task support to `django_ztaskq`. This was needed because I wrote a Django email backend, [django-ztaskq-mailer](https://github.com/abstract-open-solutions/django-ztaskq-mailer), that needs to retry sending a mail "some time later" when it encounters an error.

From the "user" perspective, very few has changed. The most important difference is that now you can do:

``` python
mytask.async('eggs', with='spam', and='spam', ztaskq_delay=30)
```

And your task will not be executed before the 30 seconds are expired (barred a few milliseconds difference).

In order to do this I had to refactor code a bit. I'll provide you with a quick summary of changes and their reason:
- I use `pylint` to check my code within the editor as I type, so I have "pylinted" it
- I updated the version number to 0.3.0. This is needed so I can correctly pin the dependency on my async mail backend
- I removed the use of the autoreloader, because correctly initialing and properly closing `zmq` sockets is hard enough by itself and I did not want to add the problem of having two processes running each time I launched a service (and one of the two actually happened to stay around because the thread containing the `zmq.core.device.device` just wouldn't die). In development, restarting the worker should be enough in most cases and will save you from strange `zmq` errors
- I reworked the logger a bit, so that it tries to use a separate log file for each process when possible. This forced me to add an extra, required arg to the `workerd` call, which is the name of the worker. This way one can determine on which worker happened what. Furthermore, if the path of `ZTASKD_LOG_PATH` contains `%(name)s`, the name of the process is substutituted there (so you son't have two processes fighting for the log file)
- The file logger is now a `RotatingFileHandler`, so you don't need logrotate to mess with your daemons.
- I now use `inproc://` for the `ztaskd` internal queue, so that any error that might arise from insufficient permissions on `/tmp` (as was the case with `ipc://` that uses a UNIX socket) can be averted
- I use the `atexit` module to do the shut-down cleanup
- Since Django 1.4 should have properly-timezoned timestamps passed to its models, I now use `pytz` to mark timestamps correctly as being in UTC
- I refactored the internal code of `ztaskd`, which now works slightly different: each time the server gets a new task, it spawns a thread to handle it (that is, send it to the worker via the internal "bouncer"). This thread is a normal thread that executes very fast and dies off immediately if it is not a delayed task, while if it is a delayed task the thread "sleeps" until the time to pass it to the worker has come. Also a new routine has been added to requeue eventual "left-overs" from a previous run. The only thing that's a bit shaky in it is probably the finished threads "garbage collection", but I think it works well enough for most cases.

That said, there are two big warnings to be aware of: due to my changes, this code is unlikely to work on anything that has a version of `pyzmq` older than 2.2.0 or any Django release prior to 1.4.

Thanks a lot for this piece of software!
