### PR TITLE
fix zmq imports and install with setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 *.egg-info
+build/*
+dist/*

--- a/django_ztaskq/management/commands/ztaskd.py
+++ b/django_ztaskq/management/commands/ztaskd.py
@@ -4,9 +4,7 @@ import atexit
 from datetime import datetime, timedelta
 from threading import Thread, Lock, Timer
 from pytz import utc
-from zmq import STREAMER, PUSH, PULL
-from zmq.core.device import device
-from zmq.core.error import ZMQError
+from zmq import STREAMER, PUSH, PULL, device, ZMQError
 from django.core.management.base import BaseCommand
 from ...models import Task, Status
 from ...conf import settings, get_logger

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 try:
-    from setuptools import setup
+    from setuptools import setup, find_packages
 except ImportError:
-    from distutils.core import setup
+    from distutils.core import setup, find_packages
 import django_ztaskq as distmeta
 
 setup(
@@ -11,12 +11,12 @@ setup(
     author=distmeta.__author__,
     author_email=distmeta.__contact__,
     url=distmeta.__homepage__,
-    #
+    #   
     name='django-ztaskq',
-    packages=['django_ztaskq'],
+    packages=find_packages(),
     install_requires=[
         'django-picklefield',
         'pyzmq',
         'pytz'
-    ]
+    ]   
 )


### PR DESCRIPTION
Hello!

Recent changes in zmq break ztaskq imports in management.commands.ztaskd. I have updated these and also updated setup.py to work for me - `python setup.py install` would not install the directories correctly.

Hope this helps!
